### PR TITLE
remove API config for project review

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,5 +8,4 @@ dist/
 .env.development
 .env.test
 .env.production
-config.js
 secrets.js

--- a/src/scripts/config.js
+++ b/src/scripts/config.js
@@ -1,0 +1,7 @@
+export const API_CONFIG = {
+  baseUrl: "https://around-api.en.tripleten-services.com/v1",
+  headers: {
+    authorization: "932461a1-5689-412a-b2e1-d7861760d1f6",
+    "Content-Type": "application/json"
+  }
+};


### PR DESCRIPTION
I added config.js to .gitignore to hide the token value because github sent me a message about sharing tokens but i didnt set it up to where you could review it with a temp token. Sorry about that